### PR TITLE
Removing extra { character from url path

### DIFF
--- a/src/_path.scss
+++ b/src/_path.scss
@@ -13,6 +13,6 @@
 @media screen and (-webkit-min-device-pixel-ratio:0) {
     @font-face {
         font-family: #{$la-font-name};
-        src: url('{#{$la-font-path}/line-awesome.svg?v=#{$la-version}#fa') format("svg");
+        src: url('#{$la-font-path}/line-awesome.svg?v=#{$la-version}#fa') format("svg");
     }
 }


### PR DESCRIPTION
Sorry, didn't realize how the css was built. This should be the correct fix to remove the { from the path.